### PR TITLE
Add clarity about regular expressions in event names

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,12 +117,12 @@ sudo npm install -g --unsafe-perm homebridge-calendar-scheduler@latest
 | caseInsensitiveEventsMatching | Enable for case insensitive events matching for this calendar.                                                                                    | `false`            | No       |
 | calendarEvents                | Array of watched calendar events.                                                                                                                 | `[]`               | No       |
 
-| Calendar Event Config Field   | Description                                                                                       | Default         | Required |
-|-------------------------------|---------------------------------------------------------------------------------------------------|-----------------|----------|
-| eventName                     | A unique name for the calendar event. Will be used as calendar sensor for matched calendar event. | `"event-name1"` | Yes      |
-| eventTriggerOnUpdates         | If set to true, then every minute sensor trigger update for active event.                         | `true`          | No       |
-| caseInsensitiveEventsMatching | Enable for case insensitive events matching for this event.                                       | `false`         | No       |
-| calendarEventNotifications    | Array of calendar event notifications.                                                            | `[]`            | No       |
+| Calendar Event Config Field   | Description                                                                                             | Default         | Required |
+|-------------------------------|---------------------------------------------------------------------------------------------------------|-----------------|----------|
+| eventName                     | A unique name for the calendar event. Will be used as calendar sensor for regex matched calendar event. | `"event-name1"` | Yes      |
+| eventTriggerOnUpdates         | If set to true, then every minute sensor trigger update for active event.                               | `true`          | No       |
+| caseInsensitiveEventsMatching | Enable for case insensitive events matching for this event.                                             | `false`         | No       |
+| calendarEventNotifications    | Array of calendar event notifications.                                                                  | `[]`            | No       |
 
 | Calendar Event Notification Config Field | Description                                                                                                                                                                                                                    | Default                | Required |
 |------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------|----------|

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ sudo npm install -g --unsafe-perm homebridge-calendar-scheduler@latest
 
 | Calendar Event Config Field   | Description                                                                                             | Default         | Required |
 |-------------------------------|---------------------------------------------------------------------------------------------------------|-----------------|----------|
-| eventName                     | A unique name for the calendar event. Will be used as calendar sensor for regex matched calendar event. | `"event-name1"` | Yes      |
+| eventName                     | A unique name for the calendar event. Will be used as calendar sensor for matched calendar event. Note that this can either be an event name or more generally a regular expression. | `"event-name1"` | Yes      |
 | eventTriggerOnUpdates         | If set to true, then every minute sensor trigger update for active event.                               | `true`          | No       |
 | caseInsensitiveEventsMatching | Enable for case insensitive events matching for this event.                                             | `false`         | No       |
 | calendarEventNotifications    | Array of calendar event notifications.                                                                  | `[]`            | No       |

--- a/config.schema.json
+++ b/config.schema.json
@@ -81,7 +81,7 @@
                 "properties": {
                   "eventName": {
                     "title": "Event Name",
-                    "description": "A unique name for the calendar event. Will be used as calendar sensor for matched calendar event.",
+                    "description": "A unique name for the calendar event. Will be used as calendar sensor for matched calendar event. This is used as a regular expression to match events.",
                     "placeholder": "event-name1",
                     "type": "string",
                     "default": "event-name1",


### PR DESCRIPTION
This makes it clear in the README that the eventName is used as a regular expression.
